### PR TITLE
Add MCP server directory discovery

### DIFF
--- a/client/src/components/server-connect-form.tsx
+++ b/client/src/components/server-connect-form.tsx
@@ -29,12 +29,14 @@ interface ServerConnectFormProps {
   recentServers: MCPServer[];
   onConnect: (url: string) => void;
   onRecentServerSelect: (server: MCPServer) => void;
+  onBrowseServers: () => void;
 }
 
 export function ServerConnectForm({
   recentServers,
   onConnect,
   onRecentServerSelect,
+  onBrowseServers,
 }: ServerConnectFormProps) {
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -79,6 +81,9 @@ export function ServerConnectForm({
             />
             <Button type="submit" className="w-full" disabled={form.formState.isSubmitting}>
               Connect
+            </Button>
+            <Button type="button" variant="outline" className="w-full" onClick={onBrowseServers}>
+              Browse Servers
             </Button>
           </form>
         </Form>

--- a/client/src/components/server-directory-dialog.tsx
+++ b/client/src/components/server-directory-dialog.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableCell,
+} from "@/components/ui/table";
+import { useAppStore } from "@/stores/app-store";
+import { DirectoryServer, pingServer } from "@/lib/directory";
+
+interface BrowseDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (url: string) => void;
+}
+
+export function ServerDirectoryDialog({
+  open,
+  onOpenChange,
+  onSelect,
+}: BrowseDialogProps) {
+  const { serverDirectory, loadServerDirectory } = useAppStore();
+  const [status, setStatus] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    if (open && serverDirectory.length === 0) {
+      loadServerDirectory();
+    }
+  }, [open, serverDirectory.length, loadServerDirectory]);
+
+  useEffect(() => {
+    if (!open) return;
+    serverDirectory.forEach((s) => {
+      pingServer(s.url).then((online) =>
+        setStatus((prev) => ({ ...prev, [s.url]: online }))
+      );
+    });
+  }, [open, serverDirectory]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Browse MCP Servers</DialogTitle>
+          <DialogDescription>
+            Select a server to connect.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="max-h-[60vh] overflow-y-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Endpoint</TableHead>
+                <TableHead>Tags</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {serverDirectory.map((server) => (
+                <TableRow key={server.url}>
+                  <TableCell>{server.name}</TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {server.url}
+                  </TableCell>
+                  <TableCell>
+                    {server.tags?.map((t) => (
+                      <span
+                        key={t}
+                        className="mr-1 inline-block bg-blue-100 dark:bg-blue-800 text-blue-800 dark:text-blue-100 px-2 py-0.5 rounded text-xs"
+                      >
+                        {t}
+                      </span>
+                    ))}
+                  </TableCell>
+                  <TableCell>
+                    {status[server.url] == null
+                      ? "..."
+                      : status[server.url]
+                      ? "Online"
+                      : "Offline"}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button size="sm" onClick={() => onSelect(server.url)}>
+                      Connect
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/client/src/lib/directory.ts
+++ b/client/src/lib/directory.ts
@@ -1,0 +1,134 @@
+import { DirectoryServer } from "@/shared/types";
+
+const DB_NAME = "mcp-browser";
+const STORE_NAME = "server-directory";
+const STORE_KEY = "data";
+const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24h
+
+async function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+  });
+}
+
+async function loadFromCache(): Promise<{ timestamp: number; data: DirectoryServer[] } | null> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readonly");
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.get(STORE_KEY);
+    req.onsuccess = () => resolve(req.result || null);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function saveToCache(data: DirectoryServer[]): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+    const store = tx.objectStore(STORE_NAME);
+    store.put({ timestamp: Date.now(), data }, STORE_KEY);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function fetchFromGitHub(): Promise<DirectoryServer[]> {
+  const res = await fetch(
+    "https://raw.githubusercontent.com/punkpeye/awesome-mcp-servers/main/servers.json",
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch directory: ${res.status}`);
+  }
+  return await res.json();
+}
+
+async function fetchFromMcpServers(): Promise<DirectoryServer[]> {
+  const res = await fetch("https://mcpservers.org");
+  if (!res.ok) {
+    throw new Error(`Failed to fetch directory HTML: ${res.status}`);
+  }
+  const text = await res.text();
+  const doc = new DOMParser().parseFromString(text, "text/html");
+  const rows = Array.from(doc.querySelectorAll("tr"));
+  const servers: DirectoryServer[] = [];
+
+  for (const row of rows) {
+    const name = row.querySelector(".name")?.textContent?.trim();
+    const url = row.querySelector("a[href^='http']")?.getAttribute("href") || "";
+    const tagsText = row.querySelector(".tags")?.textContent || "";
+    if (url) {
+      servers.push({
+        name: name || url,
+        url,
+        tags: tagsText
+          .split(/[,\s]+/)
+          .map((t) => t.trim())
+          .filter(Boolean),
+      });
+    }
+  }
+
+  return servers;
+}
+
+/** Fetch the directory, using cache if available */
+export async function getServerDirectory(forceRefresh = false): Promise<DirectoryServer[]> {
+  if (!forceRefresh) {
+    try {
+      const cached = await loadFromCache();
+      if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
+        return cached.data;
+      }
+    } catch {
+      // ignore cache errors
+    }
+  }
+
+  let data: DirectoryServer[] = [];
+  try {
+    data = await fetchFromGitHub();
+  } catch {
+    try {
+      data = await fetchFromMcpServers();
+    } catch {
+      data = [];
+    }
+  }
+
+  if (data.length) {
+    try {
+      await saveToCache(data);
+    } catch {
+      // ignore cache errors
+    }
+  }
+
+  return data;
+}
+
+export async function pingServer(url: string, timeout = 5000): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), timeout);
+    const res = await fetch(`${url.replace(/\/$/, "")}/manifest`, {
+      method: "GET",
+      signal: controller.signal,
+    });
+    clearTimeout(id);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export type { DirectoryServer } from "@/shared/types";
+

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
 import { ServerConnectForm } from "@/components/server-connect-form";
+import { ServerDirectoryDialog } from "@/components/server-directory-dialog";
 import { AuthForm } from "@/components/auth-form";
 import { ToolCatalog } from "@/components/tool-catalog";
 import { ToolDetail } from "@/components/tool-detail";
@@ -41,6 +42,8 @@ export default function Home() {
     // History
     recentServers,
   } = useAppStore();
+
+  const [directoryOpen, setDirectoryOpen] = useState(false);
   
   // Handle initial connection to server
   const handleConnect = (url: string) => {
@@ -55,6 +58,11 @@ export default function Home() {
   // Handle authentication
   const handleAuthenticate = (token: string, remember: boolean) => {
     authenticate(token, remember);
+  };
+
+  const handleDirectorySelect = (url: string) => {
+    setDirectoryOpen(false);
+    connect(url);
   };
   
   // Handle tool execution
@@ -76,6 +84,7 @@ export default function Home() {
               recentServers={recentServers}
               onConnect={handleConnect}
               onRecentServerSelect={handleRecentServerSelect}
+              onBrowseServers={() => setDirectoryOpen(true)}
             />
           </div>
         )}
@@ -174,6 +183,11 @@ export default function Home() {
       </main>
       
       <Footer />
+      <ServerDirectoryDialog
+        open={directoryOpen}
+        onOpenChange={setDirectoryOpen}
+        onSelect={handleDirectorySelect}
+      />
     </div>
   );
 }

--- a/client/src/shared/types.ts
+++ b/client/src/shared/types.ts
@@ -11,6 +11,12 @@ export interface MCPServerWithAuth extends MCPServer {
   authToken: string;
 }
 
+export interface DirectoryServer {
+  name: string;
+  url: string;
+  tags?: string[];
+}
+
 // MCP Manifest types
 export interface MCPManifest {
   name: string;
@@ -122,6 +128,9 @@ export interface AppState {
   filteredTools: MCPTool[];
   searchQuery: string;
   activeTags: string[];
+
+  // Directory
+  serverDirectory: DirectoryServer[];
   
   // Execution state
   currentExecution?: ToolExecution;

--- a/client/src/stores/app-store.ts
+++ b/client/src/stores/app-store.ts
@@ -1,6 +1,13 @@
 import { create } from "zustand";
 import { MCPClient, createToolExecution, completeToolExecution } from "@/lib/mcp-client";
-import { AppState, MCPServer, MCPTool, ToolExecution } from "@/shared/types";
+import {
+  AppState,
+  MCPServer,
+  MCPTool,
+  ToolExecution,
+  DirectoryServer,
+} from "@/shared/types";
+import { getServerDirectory } from "@/lib/directory";
 import { saveServer, saveAuthToken, getAuthToken, saveExecution, loadHistory } from "@/lib/storage";
 import { useToast } from "@/hooks/use-toast";
 
@@ -20,6 +27,8 @@ const initialState: AppState = {
   filteredTools: [],
   searchQuery: "",
   activeTags: [],
+
+  serverDirectory: [],
   
   // Execution state
   isExecuting: false,
@@ -36,6 +45,7 @@ const history = loadHistory();
 export const useAppStore = create<
   AppState & {
     recentServers: MCPServer[];
+    serverDirectory: DirectoryServer[];
     
     // Actions
     connect: (url: string) => Promise<void>;
@@ -45,10 +55,12 @@ export const useAppStore = create<
     selectTool: (tool: MCPTool) => void;
     executeTool: (tool: MCPTool, inputs: Record<string, any>) => Promise<void>;
     clearExecution: () => void;
+    loadServerDirectory: () => Promise<void>;
   }
 >((set, get) => ({
   ...initialState,
   recentServers: history.recentServers,
+  serverDirectory: [],
   
   // Connect to a server
   connect: async (url: string) => {
@@ -256,5 +268,10 @@ export const useAppStore = create<
     set({
       currentExecution: undefined,
     });
+  },
+
+  loadServerDirectory: async () => {
+    const directory = await getServerDirectory();
+    set({ serverDirectory: directory });
   },
 }));


### PR DESCRIPTION
## Summary
- implement server directory loader with IndexedDB caching and ping
- expose directory via zustand store
- add server browsing dialog with quick connect
- support browsing servers from connect form and home page

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*