### PR TITLE
Enhance layout and add command palette

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import NotFound from "@/pages/not-found";
 import Home from "@/pages/home";
+import { CommandPalette } from "@/components/command-palette";
 
 function Router() {
   return (
@@ -20,6 +21,7 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <Toaster />
+        <CommandPalette />
         <Router />
       </TooltipProvider>
     </QueryClientProvider>

--- a/client/src/components/command-palette.tsx
+++ b/client/src/components/command-palette.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandGroup,
+  CommandItem,
+  CommandEmpty,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { useAppStore } from "@/stores/app-store";
+import { loadHistory } from "@/lib/storage";
+import { History, Server, Terminal } from "lucide-react";
+
+export function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const { recentServers, connect, tools, selectTool, isConnected } = useAppStore();
+  const [executions] = useState(() => loadHistory().executions);
+
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if ((e.key === "k" || e.key === "K") && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+    };
+    window.addEventListener("keydown", down);
+    return () => window.removeEventListener("keydown", down);
+  }, []);
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen}>
+      <CommandInput placeholder="Search tools or servers..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Servers">
+          {recentServers.map((server) => (
+            <CommandItem
+              key={server.url}
+              onSelect={() => {
+                connect(server.url);
+                setOpen(false);
+              }}
+            >
+              <Server className="mr-2 h-4 w-4" />
+              {server.name || server.url}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+        {isConnected && (
+          <>
+            <CommandSeparator />
+            <CommandGroup heading="Tools">
+              {tools.map((tool) => (
+                <CommandItem
+                  key={tool.slug}
+                  onSelect={() => {
+                    selectTool(tool);
+                    useAppStore.setState({ activeView: "main", activeTab: "detail" });
+                    setOpen(false);
+                  }}
+                >
+                  <Terminal className="mr-2 h-4 w-4" />
+                  {tool.name}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </>
+        )}
+        {executions.length > 0 && (
+          <>
+            <CommandSeparator />
+            <CommandGroup heading="History">
+              {executions.slice(0, 5).map((ex, i) => (
+                <CommandItem
+                  key={i}
+                  onSelect={() => {
+                    useAppStore.setState({
+                      activeView: "main",
+                      activeTab: "output",
+                      currentExecution: ex,
+                    });
+                    setOpen(false);
+                  }}
+                >
+                  <History className="mr-2 h-4 w-4" />
+                  {ex.toolName}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </>
+        )}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/client/src/components/execution-viewer.tsx
+++ b/client/src/components/execution-viewer.tsx
@@ -5,6 +5,7 @@ import { useToast } from "@/hooks/use-toast";
 import { ToolExecution } from "@/shared/types";
 import { formatExecutionTime, renderResponse, determineResponseType } from "@/lib/response-renderer";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ExecutionSkeleton } from "@/components/skeletons";
 
 interface ExecutionViewerProps {
   execution?: ToolExecution;
@@ -162,29 +163,35 @@ export function ExecutionViewer({ execution, onClear }: ExecutionViewerProps) {
             <div className="prose prose-sm dark:prose-invert max-w-none">
               {renderOutput(execution.outputs)}
             </div>
+          ) : execution.status === "running" ? (
+            <ExecutionSkeleton />
           ) : (
-            <div className="text-gray-500 dark:text-gray-400">
-              {execution.status === "running" ? "Waiting for results..." : "No output available"}
-            </div>
+            <div className="text-gray-500 dark:text-gray-400">No output available</div>
           )}
         </TabsContent>
         
         <TabsContent value="console" className="flex-1 overflow-auto p-4 bg-gray-900 m-0 border-0">
-          <pre className="font-mono text-xs text-gray-300 whitespace-pre-wrap">
-            {execution.logs.length > 0 
-              ? execution.logs.join("\n") 
-              : "No logs available"
-            }
-          </pre>
+          {execution.logs.length > 0 ? (
+            <pre className="font-mono text-xs text-gray-300 whitespace-pre-wrap">
+              {execution.logs.join("\n")}
+            </pre>
+          ) : execution.status === "running" ? (
+            <ExecutionSkeleton />
+          ) : (
+            <pre className="font-mono text-xs text-gray-300 whitespace-pre-wrap">No logs available</pre>
+          )}
         </TabsContent>
         
         <TabsContent value="raw" className="flex-1 overflow-auto p-4 bg-gray-900 m-0 border-0">
-          <pre className="font-mono text-xs text-gray-300 whitespace-pre-wrap">
-            {execution.outputs
-              ? JSON.stringify(execution.outputs, null, 2)
-              : "No data available"
-            }
-          </pre>
+          {execution.outputs ? (
+            <pre className="font-mono text-xs text-gray-300 whitespace-pre-wrap">
+              {JSON.stringify(execution.outputs, null, 2)}
+            </pre>
+          ) : execution.status === "running" ? (
+            <ExecutionSkeleton />
+          ) : (
+            <pre className="font-mono text-xs text-gray-300 whitespace-pre-wrap">No data available</pre>
+          )}
         </TabsContent>
       </Tabs>
     </div>

--- a/client/src/components/skeletons.tsx
+++ b/client/src/components/skeletons.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function ManifestSkeleton() {
+  return (
+    <div className="space-y-4 w-full max-w-md">
+      <Skeleton className="h-8 w-3/4" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+    </div>
+  );
+}
+
+export function ExecutionSkeleton() {
+  return (
+    <div className="p-4 space-y-2">
+      <Skeleton className="h-4 w-1/3" />
+      <Skeleton className="h-32 w-full" />
+    </div>
+  );
+}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -6,6 +6,7 @@ import { AuthForm } from "@/components/auth-form";
 import { ToolCatalog } from "@/components/tool-catalog";
 import { ToolDetail } from "@/components/tool-detail";
 import { ExecutionViewer } from "@/components/execution-viewer";
+import { ManifestSkeleton } from "@/components/skeletons";
 import { useAppStore } from "@/stores/app-store";
 import { MCPServer } from "@/shared/types";
 
@@ -14,6 +15,7 @@ export default function Home() {
     // Connection state
     isConnected,
     isConnecting,
+    connectionError,
     serverUrl,
     connect,
     disconnect,
@@ -21,6 +23,7 @@ export default function Home() {
     // Auth state
     requiresAuth,
     isAuthenticating,
+    authError,
     authenticate,
     cancelAuth,
     
@@ -33,6 +36,7 @@ export default function Home() {
     currentExecution,
     executeTool,
     clearExecution,
+    executionError,
     
     // UI state
     activeView,
@@ -71,31 +75,45 @@ export default function Home() {
       <main className="flex-grow flex flex-col">
         {/* URL Input Landing (Initial View) */}
         {activeView === "url" && (
-          <div className="flex-grow flex items-center justify-center px-4 py-10 sm:px-6 lg:px-8">
-            <ServerConnectForm
-              recentServers={recentServers}
-              onConnect={handleConnect}
-              onRecentServerSelect={handleRecentServerSelect}
-            />
+          <div className="flex-grow flex flex-col items-center justify-center px-4 py-10 sm:px-6 lg:px-8 space-y-4">
+            {isConnecting ? (
+              <ManifestSkeleton />
+            ) : (
+              <ServerConnectForm
+                recentServers={recentServers}
+                onConnect={handleConnect}
+                onRecentServerSelect={handleRecentServerSelect}
+              />
+            )}
+            {connectionError && (
+              <p className="text-sm text-red-500 text-center">{connectionError}</p>
+            )}
           </div>
         )}
         
         {/* Auth Form View */}
         {activeView === "auth" && (
-          <div className="flex-grow flex items-center justify-center px-4 py-10 sm:px-6 lg:px-8">
-            <AuthForm
-              serverUrl={serverUrl}
-              onAuthenticate={handleAuthenticate}
-              onCancel={cancelAuth}
-            />
+          <div className="flex-grow flex flex-col items-center justify-center px-4 py-10 sm:px-6 lg:px-8 space-y-4">
+            {isAuthenticating ? (
+              <ManifestSkeleton />
+            ) : (
+              <AuthForm
+                serverUrl={serverUrl}
+                onAuthenticate={handleAuthenticate}
+                onCancel={cancelAuth}
+              />
+            )}
+            {authError && (
+              <p className="text-sm text-red-500 text-center">{authError}</p>
+            )}
           </div>
         )}
         
         {/* Main Application View */}
         {activeView === "main" && (
-          <div className="flex-grow">
+          <div className="flex-grow container mx-auto grid grid-cols-12 gap-4">
             {/* Tab navigation for mobile */}
-            <div className="sm:hidden bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+            <div className="sm:hidden col-span-12 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
               <div className="px-4 sm:px-6 lg:px-8">
                 <nav className="flex space-x-4" aria-label="Tabs">
                   <button 
@@ -133,9 +151,9 @@ export default function Home() {
             </div>
             
             {/* Desktop layout (side by side) */}
-            <div className="flex flex-col sm:flex-row flex-grow">
+            <div className="col-span-12 grid grid-cols-12 gap-4 flex-grow">
               {/* Left Panel (Tools Catalog + Tool Detail) */}
-              <div className="w-full sm:w-2/5 lg:w-1/3 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col">
+              <div className="col-span-12 md:col-span-4 lg:col-span-3 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col">
                 {/* Catalog view */}
                 {(activeTab === "catalog" || !selectedTool) && (
                   <ToolCatalog
@@ -158,8 +176,8 @@ export default function Home() {
               </div>
               
               {/* Right Panel (Execution Viewer) */}
-              <div 
-                className={`w-full sm:w-3/5 lg:w-2/3 bg-gray-50 dark:bg-gray-900 flex flex-col overflow-hidden ${
+              <div
+                className={`col-span-12 md:col-span-8 lg:col-span-9 bg-gray-50 dark:bg-gray-900 flex flex-col overflow-hidden ${
                   activeTab === "output" || activeTab === "detail" ? "flex" : "hidden sm:flex"
                 }`}
               >
@@ -169,6 +187,9 @@ export default function Home() {
                 />
               </div>
             </div>
+            {executionError && (
+              <p className="col-span-12 text-center text-red-500 text-sm">{executionError}</p>
+            )}
           </div>
         )}
       </main>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,6 +4,10 @@ export default {
   darkMode: ["class"],
   content: ["./client/index.html", "./client/src/**/*.{js,jsx,ts,tsx}"],
   theme: {
+    container: {
+      center: true,
+      padding: "1rem",
+    },
     extend: {
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary
- add keyboard-driven command palette for quick navigation
- show skeletons while connecting or running a tool
- switch main layout to a container-based 12-column grid
- display execution errors inline
- configure Tailwind container

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*