### PR TITLE
Improve MCP client spec compliance

### DIFF
--- a/client/src/shared/types.ts
+++ b/client/src/shared/types.ts
@@ -2,7 +2,7 @@
 export interface MCPServer {
   url: string;
   name?: string;
-  authType?: "none" | "bearer" | "apiKey";
+  authType?: "none" | "bearer" | "apiKey" | "oauth_pkce" | "api_key";
   lastConnected?: string;
   authToken?: string;
 }
@@ -17,8 +17,13 @@ export interface MCPManifest {
   description?: string;
   version?: string;
   auth?: {
-    type: "none" | "bearer" | "apiKey";
+    type: "none" | "bearer" | "apiKey" | "oauth_pkce" | "api_key";
     required: boolean;
+    name?: string;
+    header?: string;
+    authorizationUrl?: string;
+    tokenUrl?: string;
+    scopes?: string[];
   };
   tools: MCPTool[];
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "node --test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/tests/sse.test.js
+++ b/tests/sse.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Readable } from 'node:stream';
+import { MCPClient } from '../client/src/lib/mcp-client.js';
+
+// small shim to test SSE parser
+const client = new MCPClient('http://example.com');
+
+async function collect(stream) {
+  const arr = [];
+  for await (const e of stream) arr.push(e);
+  return arr;
+}
+
+test('parseSSE basic event', async () => {
+  const data = 'event: log\ndata: "hello"\n\n';
+  const resp = new Response(Readable.from([data]), { headers: { 'content-type': 'text/event-stream' } });
+  const gen = client['parseSSE'](resp);
+  const events = await collect(gen);
+  assert.deepEqual(events, [{ type: 'log', data: '"hello"' }]);
+});


### PR DESCRIPTION
## Summary
- implement endpoint discovery and SSE parser with reconnection
- add auth header handling for bearer, api key and oauth
- extend manifest and server TypeScript types
- basic node test for SSE parser
- expose test script

## Testing
- `npm test` *(fails: cannot find module 'client/src/lib/mcp-client.js')*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing type definitions)*